### PR TITLE
Add simple HTTP server to demonstrate chaosd JVM exception injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
-"# personal-projects" 
-# comment to demo CI
-# Comment for interns demo master
+# personal-projects
+
+This repository now contains a tiny Java HTTP server that can be used with
+[`chaosd`](https://github.com/chaos-mesh/chaosd) to inject a
+`java.lang.RuntimeException("CHAOS-TEST")` into a running JVM.
+
+## Running the demo server
+
+```bash
+mvn package
+java -cp target/personal-projects-1.0-SNAPSHOT.jar com.calsoft.App
+```
+
+The application listens on `http://localhost:8080/` and logs every request
+via `ChaosDemoService.processRequest()`.
+
+## Triggering a chaos experiment
+
+1. Find the JVM process ID (PID) of the running server.
+2. Execute the following command, replacing placeholders with the actual
+   class, method and PID values:
+
+```bash
+chaosd attack jvm exception \
+  -c com.calsoft.ChaosDemoService \
+  -m processRequest \
+  --exception 'java.lang.RuntimeException("CHAOS-TEST")' \
+  --pid <PID>
+```
+
+The injected exception is caught by the HTTP handler and printed to the
+application console so it is easy to verify that the chaos attack worked.

--- a/src/main/java/com/calsoft/App.java
+++ b/src/main/java/com/calsoft/App.java
@@ -1,15 +1,60 @@
 package com.calsoft;
 
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Executors;
+
 /**
- * Hello world!
- *
+ * Simple HTTP server that delegates to {@link ChaosDemoService} so that
+ * chaosd can inject exceptions into the JVM. Requests to / trigger the
+ * service call and the response is written back to the client.
  */
-public class App 
-{
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
-        //added changes to test scm build fire 2
-        //testing webhooks3
+public class App {
+
+    private static final int PORT = 8080;
+
+    public static void main(String[] args) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        server.createContext("/", new ChaosHandler(new ChaosDemoService()));
+        server.setExecutor(Executors.newFixedThreadPool(2));
+
+        System.out.println("Starting HTTP server on port " + PORT);
+        server.start();
+    }
+
+    private static class ChaosHandler implements HttpHandler {
+        private final ChaosDemoService service;
+
+        private ChaosHandler(ChaosDemoService service) {
+            this.service = service;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String response;
+            int statusCode = 200;
+            try {
+                response = service.processRequest();
+            } catch (RuntimeException exception) {
+                // Log the chaosd injected exception to the console and
+                // return a 500 to the caller so that it is visible.
+                System.err.println("Encountered exception in processRequest: " + exception);
+                exception.printStackTrace(System.err);
+                response = "Chaos exception encountered: " + exception.getMessage();
+                statusCode = 500;
+            }
+
+            byte[] responseBytes = response.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(statusCode, responseBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBytes);
+            }
+        }
     }
 }

--- a/src/main/java/com/calsoft/ChaosDemoService.java
+++ b/src/main/java/com/calsoft/ChaosDemoService.java
@@ -1,0 +1,20 @@
+package com.calsoft;
+
+/**
+ * Service class with a method that chaosd can instrument to throw an exception.
+ * The {@link #processRequest()} method simply logs to stdout and returns a
+ * message when no chaos experiment is running.
+ */
+public class ChaosDemoService {
+
+    /**
+     * Method intentionally left simple so chaosd can inject
+     * {@code java.lang.RuntimeException("CHAOS-TEST")} via the JVM attack.
+     *
+     * @return message for successful calls.
+     */
+    public String processRequest() {
+        System.out.println("Processing request in ChaosDemoService.processRequest()");
+        return "Request processed successfully";
+    }
+}


### PR DESCRIPTION
## Summary
- replace the console-only demo with a tiny HTTP server that exposes a root endpoint
- add a dedicated service method so chaosd can inject a RuntimeException and print it to the console
- document how to run the server and execute the chaosd JVM exception attack

## Testing
- `mvn -q package` *(fails: repository access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbfcdaf0fc8324ba891773cce6a7cd